### PR TITLE
Configurable progress paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,14 @@ A config file is used to pass all the parameters, the goal is to make it easy to
     "LOCAL_ZIP_SPACE": "30GB", # Size of the temporary zip area in human readable size, to avoid overflowing disks
     "IRODS_TARGET_PATH": "", # ignored due to bug, see notes
     "METADATA_EXCEL": "test_metadata.xlsx" # Excel file with the list of files to upload and metadata
-    "PROGRESS_FILE": "progres.csv" "optional: absolute location of the progress csv file. uses the current working directory if only a filename is entered."
+    "PROGRESS_FILE": "progres.csv" "optional: absolute location of the progress csv file. uses the current working directory if only a filename is entered. The default location is the directory of the code."
 }
 ```
+
+The default location of the config file is the code folder, the config file can also be passed as an argument:
+`python main.py --config path/to/config.json`
+
+
 
 ### Zipping
 The default zip implementations in python work, but they are awfully slow. As is windows itself. In the search for alternatives this comparison came up: https://peazip.github.io/peazip-compression-benchmark.html

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ A config file is used to pass all the parameters, the goal is to make it easy to
     "LOCAL_ZIP_SPACE": "30GB", # Size of the temporary zip area in human readable size, to avoid overflowing disks
     "IRODS_TARGET_PATH": "", # ignored due to bug, see notes
     "METADATA_EXCEL": "test_metadata.xlsx" # Excel file with the list of files to upload and metadata
+    "PROGRESS_FILE": "progres.csv" "optional: absolute location of the progress csv file. uses the current working directory if only a filename is entered."
 }
 ```
 

--- a/iRODS_ingest/main.py
+++ b/iRODS_ingest/main.py
@@ -50,6 +50,12 @@ if __name__ == "__main__":
         exit(1)
     config = utils.load_json(config_file)
 
+    # Prep progress CSV path
+    if 'PROGRESS_FILE' in config.keys() and config['PROGRESS_FILE'] and Path(config['PROGRESS_FILE']).parent.is_dir():
+        progress_file_path = Path(config['PROGRESS_FILE'])
+    else:
+        progress_file_path = Path(__file__).parent.joinpath('in_progress.csv')
+
     # Retreive users password, used to mount the W if desired and login to iRODS
     password = getpass('Your iRODS password')
 
@@ -66,7 +72,7 @@ if __name__ == "__main__":
     # Only uploads the files with a 'v' in the '_to_upload' column
     if Path(__file__).parent.joinpath('in_progress.csv').exists():
         logging.info('Found in_progress.csv, continuing from there')
-        to_upload_df = pd.read_csv(Path(__file__).parent.joinpath('in_progress.csv'))
+        to_upload_df = pd.read_csv(progress_file_path)
     else:
         metada_df = pd.read_excel(Path(source_path).joinpath(config['METADATA_EXCEL']),
                                   skiprows=0, engine="openpyxl")
@@ -75,7 +81,7 @@ if __name__ == "__main__":
             to_upload_df['_status'] = ""
         to_upload_df['_status'] = to_upload_df['_status'].astype(str)
         to_upload_df = create_task_df(to_upload_df, source_path, target_ipath, zip_path, isession)
-        to_upload_df.to_csv(Path(__file__).parent.joinpath('in_progress.csv'), index=False)
+        to_upload_df.to_csv(progress_file_path, index=False)
 
     # Create the shared objects
     ff_to_zip_queue = multiprocessing.Queue()
@@ -152,7 +158,7 @@ if __name__ == "__main__":
             else:
                 to_upload_queue.put(row.to_dict())
     # Update the progress csv
-    to_upload_df.to_csv(Path(__file__).parent.joinpath('in_progress.csv'), index=False)
+    to_upload_df.to_csv(progress_file_path, index=False)
 
     # Add the None jobs to signal the process they are done
     for i in range(0, config['NUM_ZIPPERS']):
@@ -192,7 +198,7 @@ if __name__ == "__main__":
                     to_upload_df.at[row_index, '_status'] = 'Zipped FF'
 
                     to_upload_df = queue_multipart_zips(to_upload_queue, to_upload_df, zipped_dfrow)
-                    to_upload_df.to_csv(Path(__file__).parent.joinpath('in_progress.csv'), index=False)
+                    to_upload_df.to_csv(progress_file_path, index=False)
             except queue.Empty:
                 pass
 
@@ -210,7 +216,7 @@ if __name__ == "__main__":
             else:
                 row_index = to_upload_df.loc[to_upload_df['_iPath'] == i_path].index[0]
                 to_upload_df.at[row_index, '_status'] = 'Uploaded'
-                to_upload_df.to_csv(Path(__file__).parent.joinpath('in_progress.csv'), index=False)
+                to_upload_df.to_csv(progress_file_path, index=False)
                 # Cleanup the zip file if it was created
                 if to_upload_df.at[row_index, '_zipPath']:
                     if Path(to_upload_df.at[row_index, '_zipPath']).exists():
@@ -226,21 +232,21 @@ if __name__ == "__main__":
         if row['_status'] == 'Uploaded':
             ioperations.add_metadata(isession, row)
             to_upload_df.at[ind, '_status'] = 'Metadata added'
-    to_upload_df.to_csv(Path(__file__).parent.joinpath('in_progress.csv'), index=False)
+    to_upload_df.to_csv(progress_file_path, index=False)
 
     # Send to tape
     # for ind, row in to_upload_df.iterrows():
     #     if row['_status'] == 'Metadata added':
     #         if ioperations.send_to_tape(isession, row):
     #             to_upload_df.at[ind, '_status'] = 'Sent to tape'
-    # to_upload_df.to_csv(Path(__file__).parent.joinpath('in_progress.csv'), index=False)
+    # to_upload_df.to_csv(progress_file_path, index=False)
 
     # Check taping status
     for ind, row in to_upload_df.iterrows():
         if row['_status'] == 'Sent to tape':
             if ioperations.check_status(isession, row):
                 to_upload_df.at[ind, '_status'] = 'Archived'
-    to_upload_df.to_csv(Path(__file__).parent.joinpath('in_progress.csv'), index=False)
+    to_upload_df.to_csv(progress_file_path, index=False)
 
     # Print the summary of the statuses
     status_counts = to_upload_df['_status'].value_counts()

--- a/iRODS_ingest/main.py
+++ b/iRODS_ingest/main.py
@@ -23,7 +23,7 @@ def queue_multipart_zips(to_upload_queue, upload_df, row_dict):
     # Single zip
     if len(parts) == 1:
         to_upload_queue.put(row_dict)
-        return
+        return upload_df
 
     # Multipart zip
     row_dict['_status'] = 'Zipped FF'

--- a/iRODS_ingest/main.py
+++ b/iRODS_ingest/main.py
@@ -1,5 +1,6 @@
 from getpass import getpass
 from pathlib import Path
+import argparse
 import logging
 import multiprocessing
 import pandas as pd
@@ -43,8 +44,16 @@ def queue_multipart_zips(to_upload_queue, upload_df, row_dict):
 
 
 if __name__ == "__main__":
+    # Parse arguments
+    parser = argparse.ArgumentParser(description="Script to process and upload files.")
+    parser.add_argument('--config', type=str, required=False, help='Path to the config file')
+    args = parser.parse_args()
+
     # Check and load the config
-    config_file = Path(__file__).parent.joinpath("config.json")
+    if args.config:
+        config_file = Path(args.config)
+    else:
+        config_file = Path(__file__).parent.joinpath("config.json")
     if not utils.check_file_exists(config_file):
         logging.error('Missing config file, exiting')
         exit(1)


### PR DESCRIPTION
Add support for configurable progress paths.
When uploading big files from a server its nice to store it with the code.
When having multiple instances running at the same time this gives conflicts and it might be nicer to store the the file with the metadata excel. 

To support this we also added an argument to the main functions so users can pass the config files location.
