### PR TITLE
Fix a empty zip bug and add -t parameter

### DIFF
--- a/iRODS_ingest/ioperations.py
+++ b/iRODS_ingest/ioperations.py
@@ -72,8 +72,11 @@ def send_to_tape(session, row):
                                       body='rdm_archive_this',
                                       params={'*file_or_collection': str(i_path)})
         if stderr == "" and 'will be tagged.' in stdout:
+            logging.info(f"Sending to tape {i_path}")
             return True
+            
         else:
+            logging.error(f"Sending to tape failed for {i_path}")
             return False
 
 

--- a/iRODS_ingest/main.py
+++ b/iRODS_ingest/main.py
@@ -47,8 +47,8 @@ if __name__ == "__main__":
     # Parse arguments
     parser = argparse.ArgumentParser(description="Script to process and upload files.")
     parser.add_argument('--config', type=str, required=False, help='Path to the config file')
-    parser.add_argument('-t','--totape',dest= 'totape', default = None, required=False, 
-                        action="store_true", help = 'Add this flag to send files to tape')
+    parser.add_argument('-t', '--totape', dest='totape', default=False, required=False, 
+                        action="store_true", help='Add this flag to send files to tape')
     args = parser.parse_args()
 
     # Check and load the config
@@ -251,7 +251,7 @@ if __name__ == "__main__":
             if row['_status'] == 'Metadata added':
                 if ioperations.send_to_tape(isession, row):
                     to_upload_df.at[ind, '_status'] = 'Sent to tape'
-        to_upload_df.to_csv(progress_file, index=False)
+        to_upload_df.to_csv(progress_file_path, index=False)
 
     # Check taping status
     for ind, row in to_upload_df.iterrows():

--- a/iRODS_ingest/main.py
+++ b/iRODS_ingest/main.py
@@ -47,7 +47,8 @@ if __name__ == "__main__":
     # Parse arguments
     parser = argparse.ArgumentParser(description="Script to process and upload files.")
     parser.add_argument('--config', type=str, required=False, help='Path to the config file')
-    parser.add_argument('-t','--totape',dest = 'totape', default = None, required=False, help = 'Add this flag to send files to tape')
+    parser.add_argument('-t','--totape',dest= 'totape', default = None, required=False, 
+                        action="store_true", help = 'Add this flag to send files to tape')
     args = parser.parse_args()
 
     # Check and load the config

--- a/iRODS_ingest/main.py
+++ b/iRODS_ingest/main.py
@@ -47,7 +47,7 @@ if __name__ == "__main__":
     # Parse arguments
     parser = argparse.ArgumentParser(description="Script to process and upload files.")
     parser.add_argument('--config', type=str, required=False, help='Path to the config file')
-    parser.add_argument('-t', '--totape', dest='totape', default=False, required=False, 
+    parser.add_argument('-t', '--totape', dest='totape', default=False, required=False,
                         action="store_true", help='Add this flag to send files to tape')
     args = parser.parse_args()
 


### PR DESCRIPTION
I did not know how to split the commits into two branches, but here are a few changes:
1. An empty _zipPath column in the progress file should not promt errors. I changed all instances of `if ... df['_zipPath']` to `if not pd.isna(df['_zipPath'])`
2. I added a parameter `-t` or `--totape` which, when present, activates the sending to tape behaviour. I also added an INFO and ERROR messages in the logging file when things are sent to tape (seemed logical).

I notice that some of the changes are not in the pull request, I think that is because I have already pushed to main the changes on 1, but you should see them in the commit history (sorry!). 